### PR TITLE
Add support for CTL-4100 Intuos S tablet

### DIFF
--- a/images/pad/CTL-4100.xml
+++ b/images/pad/CTL-4100.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" ?>
+<padsettings graphicwidth="165">
+	<button name="Button 1" number="1" callsign="Button 1">
+		<x1>10</x1>
+		<y1>10</y1>
+		<x2>60</x2>
+		<y2>40</y2>
+	</button>
+	<button name="Button 2" number="2" callsign="Button 2">
+		<x1>70</x1>
+		<y1>10</y1>
+		<x2>120</x2>
+		<y2>40</y2>
+	</button>
+	<button name="Button 3" number="3" callsign="Button 3">
+		<x1>130</x1>
+		<y1>10</y1>
+		<x2>180</x2>
+		<y2>40</y2>
+	</button>
+	<button name="Button 8" number="8" callsign="Button 8">
+		<x1>190</x1>
+		<y1>10</y1>
+		<x2>240</x2>
+		<y2>40</y2>
+	</button>
+</padsettings>

--- a/wacom_data.py
+++ b/wacom_data.py
@@ -72,6 +72,7 @@ class TabletIdentities:
         self.Tablets.append(Tablet("CTH-460K", "Wacom BambooPT 2FG 4x5", 0xD6))
         self.Tablets.append(Tablet("CTL-471", "Wacom Bamboo One S", 0x300))
         self.Tablets.append(Tablet("CTL-470", "Wacom Bamboo Connect Pen", 0xDD))
+        self.Tablets.append(Tablet("CTL-4100", "Wacom Intuos S Pen", 0x374))
 
     # self.Tablets.append(
     # tablet("PTK-540WL", "Wacom Intuos4 Wireless Bluetooth", 0x00)) # Stub, this needs special support


### PR DESCRIPTION
Hi, 

This PR just adds in support for the CTL-4100 wacom tablet (wacom intuos s: https://www.wacom.com/en-us/products/pen-tablets/wacom-intuos) 

To do this, it does the following: 

- Add the right hex identifier for it as a USB device
- Add an XML file identifying the 4 buttons (which go 1, 2, 3, 8... at least on my machine) 

Thanks! 